### PR TITLE
remove cmake from scoop

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -42,7 +42,6 @@ jobs:
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
           scoop bucket add extras
           scoop update
-          scoop install cmake
           scoop install sdl2
 
       - name: Build & Install(Windows)


### PR DESCRIPTION
I remove the installation of cmake from scoop, maybe conflicting because it's already installed in windows runner

you can see the installed tools here: https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#tools